### PR TITLE
feat: Adicionar suporte completo ao cert-manager para TLS automático

### DIFF
--- a/day-10/cert/production_issuer.yaml
+++ b/day-10/cert/production_issuer.yaml
@@ -1,0 +1,14 @@
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: letsencrypt-production
+spec:
+  acme:
+    server: https://acme-v02.api.letsencrypt.org/directory
+    email: mi.apferreira@gmail.com
+    privateKeySecretRef:
+      name: letsencrypt-production
+    solvers:
+      - http01:
+          ingress:
+            class: nginx

--- a/day-10/cert/staging_issuer.yaml
+++ b/day-10/cert/staging_issuer.yaml
@@ -1,0 +1,14 @@
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: letsencrypt-staging
+spec:
+  acme:
+    server: https://acme-staging-v02.api.letsencrypt.org/directory
+    email: mi.apferreira@gmail.com
+    privateKeySecretRef:
+      name: letsencrypt-staging
+    solvers:
+      - http01:
+          ingress:
+            class: nginx

--- a/day-10/ingress-nginx.yaml
+++ b/day-10/ingress-nginx.yaml
@@ -5,7 +5,13 @@ metadata:
   annotations:
     nginx.ingress.kubernetes.io/rewrite-target: /
     kubernetes.io/ingress.class: "nginx"
+    cert-manager.io/cluster-issuer: "letsencrypt-production"
+    nginx.ingress.kubernetes.io/ssl-redirect: "true"
 spec:
+  tls:
+  - hosts:
+    - giropops.mafinfo.com.br
+    secretName: giropops-tls-secret
   rules:
   - host: giropops.mafinfo.com.br
     http:


### PR DESCRIPTION
- Adicionar configuração TLS no Ingress com annotations do cert-manager
- Incluir ClusterIssuers para Let's Encrypt (produção e staging)
- Adicionar documentação completa sobre cert-manager no day-10.md:
  * Overview e funcionalidades do cert-manager
  * Processo de instalação via Helm e manifest
  * Configuração dos ClusterIssuers em day-10/cert/
  * Configuração TLS no Ingress com annotations
  * Processo completo passo a passo
  * Seção de troubleshooting para certificados
  * Links para documentação oficial

- Corrigir configuração dos ClusterIssuers (ingressClassName → class)
- Adicionar annotations para SSL redirect automático
- Incluir seção TLS completa no Ingress

Permite geração automática de certificados SSL/TLS via Let's Encrypt